### PR TITLE
Feat/ Add a way to customize tags style

### DIFF
--- a/addon/templates/components/tag-input.hbs
+++ b/addon/templates/components/tag-input.hbs
@@ -1,5 +1,5 @@
 {{#each tags as |tag index|~}}
-  <li class="emberTagInput-tag">
+  <li class="emberTagInput-tag {{tag.modifiers}}">
     {{yield tag}}
     {{#if _isRemoveButtonVisible}}
       <a class="emberTagInput-remove" {{action 'removeTag' index}}></a>

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -3,11 +3,26 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   tags: ['foo', 'bar'],
 
+  tagsObjects: [{ label: 'foo' }, { label: 'bar' }],
+
+  colors: ['green', 'red', 'purple'],
+
   readOnly: true,
 
   actions: {
     addTag(tag) {
       this.get('tags').pushObject(tag);
+    },
+
+    addTagObject(tag) {
+      this.get('tagsObjects').pushObject({
+        label: tag,
+        modifiers: this.colors[Math.floor(Math.random() * 3)]
+      });
+    },
+
+    removeTagObject(index) {
+      this.get('tagsObjects').removeAt(index);
     },
 
     removeTag(index) {

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,9 @@
+.red {
+  background-color: rgb(161, 40, 40);
+}
+.green {
+  background-color: rgb(40, 161, 40);
+}
+.purple {
+  background-color: rgb(137, 74, 153);
+}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -36,3 +36,18 @@
 {{#if currentInputValue}}
   <p>typing: {{currentInputValue}}</p>
 {{/if}}
+
+<h1>Tags as objects</h1>
+<p>You can pass tags as strings or objects. If you pass objects, use the property `modifiers` to pass extra classes to tags.</p>
+
+{{#tag-input
+  tags=tagsObjects
+  placeholder='Add a tag...'
+  ariaLabel='Add a tag input field'
+  addTag=(action 'addTagObject')
+  removeTagAtIndex=(action 'removeTagObject')
+  onKeyUp=(action 'onKeyUp')
+  as |tag|
+}}
+  {{tag.label}}
+{{/tag-input}}

--- a/tests/integration/components/tag-input-test.js
+++ b/tests/integration/components/tag-input-test.js
@@ -23,7 +23,7 @@ module('tag-input', 'Integration | Component | Ember Tag Input', function(hooks)
     this.set('tags', tags);
 
     await render(hbs`
-      <TagInput 
+      <TagInput
         @tags={{tags}}
         @addTag={{this.addTag}}
         as |tag|>
@@ -50,7 +50,7 @@ module('tag-input', 'Integration | Component | Ember Tag Input', function(hooks)
     this.set('tags', tags);
 
     await render(hbs`
-      <TagInput 
+      <TagInput
         @tags={{tags}}
         @addTag={{this.addTag}}
         as |tag|>
@@ -81,7 +81,7 @@ module('tag-input', 'Integration | Component | Ember Tag Input', function(hooks)
     this.set('tags', tags);
 
     await render(hbs`
-      <TagInput 
+      <TagInput
         @tags={{tags}}
         @addTag={{this.addTag}}
         @removeTagAtIndex={{this.removeTagAtIndex}}
@@ -116,7 +116,7 @@ module('tag-input', 'Integration | Component | Ember Tag Input', function(hooks)
     this.set('tags', tags);
 
     await render(hbs`
-      <TagInput 
+      <TagInput
         @tags={{tags}}
         @addTag={{this.addTag}}
         @allowSpacesInTags={{true}}
@@ -140,7 +140,7 @@ module('tag-input', 'Integration | Component | Ember Tag Input', function(hooks)
     this.set('tags', tags);
 
     await render(hbs`
-      <TagInput 
+      <TagInput
         @tags={{tags}}
         @readOnly={{true}}
         as |tag|>
@@ -171,7 +171,7 @@ module('tag-input', 'Integration | Component | Ember Tag Input', function(hooks)
     };
 
     await render(hbs`
-    <TagInput 
+    <TagInput
       @tags={{tags}}
       @addTag={{this.addTag}}
       @onKeyUp={{this.onKeyUp}}
@@ -206,7 +206,7 @@ module('tag-input', 'Integration | Component | Ember Tag Input', function(hooks)
     this.set('readOnly', true);
 
     await render(hbs`
-      <TagInput 
+      <TagInput
         @tags={{tags}}
         @addTag={{this.addTag}}
         @readOnly={{readOnly}}
@@ -243,7 +243,7 @@ module('tag-input', 'Integration | Component | Ember Tag Input', function(hooks)
     };
 
     await render(hbs`
-      <TagInput 
+      <TagInput
         @tags={{tags}}
         @addTag={{this.addTag}}
         @readOnly={{readOnly}}
@@ -263,11 +263,35 @@ module('tag-input', 'Integration | Component | Ember Tag Input', function(hooks)
 
     assert.equal(findAll('.emberTagInput-tag').length, 2);
 
-    //Try deleting 
+    //Try deleting
 
-    await triggerKeyEvent(find('.js-ember-tag-input-new'), 'keydown', KEY_CODES.BACKSPACE); 
-    await triggerKeyEvent(find('.js-ember-tag-input-new'), 'keydown', KEY_CODES.BACKSPACE); 
+    await triggerKeyEvent(find('.js-ember-tag-input-new'), 'keydown', KEY_CODES.BACKSPACE);
+    await triggerKeyEvent(find('.js-ember-tag-input-new'), 'keydown', KEY_CODES.BACKSPACE);
 
     assert.equal(findAll('.emberTagInput-tag').length, 2);
+  });
+
+  test('Tags as objects rely on property @modifiers to get custom classes', async function(assert) {
+    const tags = Ember.A([{
+      label: 'hamburger',
+      modifiers: 'burger-style meat-style'
+    }, {
+      label: 'cheeseburger',
+      modifiers: 'burger-style cheese-style'
+    }]);
+
+    this.set('tags', tags);
+
+    await render(hbs`
+      <TagInput
+        @tags={{tags}}
+      as |tag|>
+        {{tag.label}}
+      </TagInput>
+    `);
+
+    let tagsElements = findAll('.emberTagInput-tag')
+    assert.ok(tagsElements[0].className.includes('burger-style meat-style'))
+    assert.ok(tagsElements[1].className.includes('burger-style cheese-style'))
   });
 });


### PR DESCRIPTION
## Features
### Add a way to customize tags style
When you pass tags as objects to the `<TagInput>` component, use the property `modifiers` to add extra classes to tags elements. 

```js
  tagsObjects: [{
    label: 'Red tag',
    modifiers: 'red'
  }, {
    label: 'Green tag',
    modifiers: 'green some-other-class'
  }],
```

Results to:
```html
<li class="emberTagInput-tag red">...</li>
<li class="emberTagInput-tag green some-other-class">...</li>
```